### PR TITLE
Feature/improve decode

### DIFF
--- a/audio8/ctc.py
+++ b/audio8/ctc.py
@@ -78,7 +78,7 @@ def prefix_beam_search(probs: np.ndarray, vocab: Dict[int, str],
                     elif v == eow:
                         p_lm = 1
                         if language_model is not None:
-                            p_lm = language_model.score(hyp_next.replace(' .', ''), True, False) * 2.302587
+                            p_lm = np.exp(language_model.score(hyp_next.replace(' .', ''), True, False) * 2.302587)
                         p_non_blank[t][hyp_next] += (p_lm**alpha) * p_at_t[c] * (p_blank[t - 1][hyp] + p_non_blank[t - 1][hyp])
                     else:
                         p_non_blank[t][hyp_next] += p_at_t[c] * (p_blank[t - 1][hyp] + p_non_blank[t - 1][hyp])

--- a/audio8/ctc.py
+++ b/audio8/ctc.py
@@ -43,7 +43,6 @@ def prefix_beam_search(probs: np.ndarray, vocab: Dict[int, str],
     blank_idx = 0
     p_blank[0][''] = 1
     p_non_blank[0][''] = 0
-
     for t in range(1, T):
         chars_above_thresh = np.where(probs[t] > min_thresh)[0]
         for hyp in A_prev:
@@ -77,10 +76,9 @@ def prefix_beam_search(probs: np.ndarray, vocab: Dict[int, str],
                         p_non_blank[t][hyp_next] += p_at_t[c] * p_blank[t - 1][hyp]
                         p_non_blank[t][hyp] += p_at_t[c] * p_non_blank[t-1][hyp]
                     elif v == eow:
-                        # TODO: add LM here
                         p_lm = 1
                         if language_model is not None:
-                            p_lm = np.exp(language_model.score(hyp_next.replace(' .', ''), True, False))
+                            p_lm = language_model.score(hyp_next.replace(' .', ''), True, False) * 2.302587
                         p_non_blank[t][hyp_next] += (p_lm**alpha) * p_at_t[c] * (p_blank[t - 1][hyp] + p_non_blank[t - 1][hyp])
                     else:
                         p_non_blank[t][hyp_next] += p_at_t[c] * (p_blank[t - 1][hyp] + p_non_blank[t - 1][hyp])

--- a/audio8/ctc.py
+++ b/audio8/ctc.py
@@ -8,6 +8,19 @@ import numpy as np
 from collections import defaultdict, Counter
 
 
+def kenlm_model(model):
+    """Creator function to score from a kenlm model
+
+    To use this, create your model and then pass `language_model=kenlm_model(model)`
+
+    :param model:
+    :return:
+    """
+    def fn(hyp_next):
+        score = 10 ** model.score(hyp_next.replace(' .', ''), True, False)
+        return score
+    return fn
+
 def prefix_beam_search(probs: np.ndarray, vocab: Dict[int, str],
                        k: int = 10,
                        min_thresh: float = 0.001,
@@ -86,7 +99,7 @@ def prefix_beam_search(probs: np.ndarray, vocab: Dict[int, str],
                     elif v == eow:
                         p_lm = 1
                         if language_model is not None:
-                            p_lm = 10 ** language_model.score(hyp_next.replace(' .', ''), True, False)
+                            p_lm = language_model(hyp_next)
 
                         p_non_blank[t][hyp_next] += (p_lm**alpha) * p_at_t[c] * (p_blank[t - 1][hyp] + p_non_blank[t - 1][hyp])
                     else:

--- a/audio8/ctc.py
+++ b/audio8/ctc.py
@@ -2,7 +2,9 @@ import torch
 import torch.nn
 import torch.nn.functional
 from eight_mile.utils import Offsets
-
+from typing import Dict, Optional, Callable
+import numpy as np
+from collections import defaultdict, Counter
 
 def logits2text(logits, vocab):
     chars = ''
@@ -22,6 +24,84 @@ def logits2text(logits, vocab):
 
     return chars
 
+
+def prefix_beam_search(logits: np.ndarray, vocab: Dict[int, str],
+                       k: int = 10,
+                       min_thresh: float = 0.0001,
+                       decoder_blank: str = '<s>',
+                       decoder_eow: str = '|',
+                       decoder_eos: str = '</s>'):
+    """Use a prefix beam search (https://arxiv.org/pdf/1408.2873.pdf) to decode
+
+    The implementation here is "Algorithm 1" from the paper, and also partly based on the excellent article here:
+    https://medium.com/corti-ai/ctc-networks-and-language-models-prefix-beam-search-explained-c11d1ee23306
+
+    :param logits: The output of a single utterance, of shape ``[T, C]``
+    :param vocab: A mapping from the integer indices of ``C`` to graphemes
+    :param p_lm: An optional language model, defaults to ``None``
+    :param k:
+    :param alpha:
+    :param beta:
+    :param min_thresh:
+    :return:
+    """
+    #p_lm = p_lm if p_lm is not None else lambda x: 1
+    p_non_blank = defaultdict(Counter)
+    p_blank = defaultdict(Counter)
+    eos = '.'
+    eow = ' '
+    A_prev = ['']
+    A_next = ['']
+    T = logits.shape[0]
+    blank_idx = 0
+    p_blank[0][''] = 1
+    p_non_blank[0][''] = 0
+
+    for t in range(1, T):
+        chars_above_thresh = np.where(logits[t] > min_thresh)[0]
+        for hyp in A_prev:
+            # If we hit the end of a sentence, already we need to propagate the probability through
+            if len(hyp) > 0 and hyp[-1] == eos:
+                p_blank[t][hyp] += p_blank[t-1][hyp]
+                p_non_blank[t][hyp] += p_non_blank[t-1][hyp]
+                A_next.append(hyp)
+                continue
+
+            p_at_t = logits[t]
+
+            for c in chars_above_thresh:
+
+                v = vocab[c]
+
+                if v == decoder_blank:
+                    p_blank[t][hyp] += p_at_t[blank_idx] * (p_blank[t-1][hyp] + p_non_blank[t-1][hyp])
+                    A_next.append(hyp)
+
+                else:
+                    v = v.replace(decoder_eos, eos).replace(decoder_eow, eow)
+                    hyp_next = hyp + v
+
+                    if v == eos:
+                        # rewrite eos to our internal repr
+                        hyp_next = hyp + eos
+                        p_non_blank[t][hyp_next] += p_at_t[c] * p_blank[t - 1][hyp]
+                        p_non_blank[t][hyp] += p_at_t[c] * p_blank[t-1][hyp]
+                    elif len(hyp) > 0 and v == hyp[-1]:
+                        p_non_blank[t][hyp_next] += p_at_t[c] * p_blank[t - 1][hyp]
+                        p_non_blank[t][hyp] += p_at_t[c] * p_non_blank[t-1][hyp]
+                    elif v == eow:
+                        # TODO: add LM here
+                        p_non_blank[t][hyp_next] += p_at_t[c] * (p_blank[t - 1][hyp] + p_non_blank[t - 1][hyp])
+                    else:
+                        p_non_blank[t][hyp_next] += p_at_t[c] * (p_blank[t - 1][hyp] + p_non_blank[t - 1][hyp])
+                    if hyp_next not in A_prev:
+                        p_blank[t][hyp_next] += p_at_t[blank_idx] * (p_blank[t - 1][hyp_next] + p_non_blank[t - 1][hyp_next])
+                        p_non_blank[t][hyp_next] += p_at_t[c] * p_non_blank[t - 1][hyp_next]
+                    A_next.append(hyp_next)
+
+        A_next = sorted(A_next, key=lambda s: (p_non_blank[t][s] + p_blank[t][s]), reverse=True)
+        A_prev = A_next[:k]
+    return A_prev[0]
 
 def postproc_letters(sentence):
     sentence = sentence.replace(" ", "").replace("|", " ").strip()

--- a/audio8/ctc.py
+++ b/audio8/ctc.py
@@ -4,6 +4,25 @@ import torch.nn.functional
 from eight_mile.utils import Offsets
 
 
+def logits2text(logits, vocab):
+    chars = ''
+    last_ltr = ''
+    eow = '|'
+    for l in logits:
+        if l in [Offsets.PAD, Offsets.EOS]:
+            continue
+
+        lower = vocab[l].lower()
+        if lower == eow:
+            lower = ' '
+        if lower != last_ltr:
+            last_ltr = lower
+            if last_ltr != '<s>':
+               chars += last_ltr
+
+    return chars
+
+
 def postproc_letters(sentence):
     sentence = sentence.replace(" ", "").replace("|", " ").strip()
     return sentence

--- a/audio8/ctc.py
+++ b/audio8/ctc.py
@@ -22,7 +22,7 @@ def kenlm_model(model):
     return fn
 
 def prefix_beam_search(probs: np.ndarray, vocab: Dict[int, str],
-                       k: int = 10,
+                       beam: int = 10,
                        min_thresh: float = 0.001,
                        decoder_blank: str = '<s>',
                        decoder_eow: str = '|',
@@ -39,7 +39,7 @@ def prefix_beam_search(probs: np.ndarray, vocab: Dict[int, str],
     :param probs: The output of a single utterance, of shape ``[T, C]``.  Should be in prob space for thresholding
     :param vocab: A mapping from the integer indices of ``C`` to graphemes
     :param min_thresh: A threshold below which to prune.  Assumes softmax
-    :param k: The beam width
+    :param beam: The beam width
     :param decoder_blank: The vocabulary blank value
     :param decoder_eow: The vocabulary end-of-word value
     :param decoder_eos: The vocabulary end-of-sentence value
@@ -111,7 +111,7 @@ def prefix_beam_search(probs: np.ndarray, vocab: Dict[int, str],
 
         A_next = list(set(A_next))
         A_next = sorted(A_next, key=score_hyp, reverse=True)
-        A_prev = A_next[:k]
+        A_prev = A_next[:beam]
 
     if return_scores:
         return [(hyp.lower(), score_hyp(hyp)) for hyp in A_prev]

--- a/audio8/ctc.py
+++ b/audio8/ctc.py
@@ -78,7 +78,8 @@ def prefix_beam_search(probs: np.ndarray, vocab: Dict[int, str],
                     elif v == eow:
                         p_lm = 1
                         if language_model is not None:
-                            p_lm = np.exp(language_model.score(hyp_next.replace(' .', ''), True, False) * 2.302587)
+                            p_lm = 10 ** language_model.score(hyp_next.replace(' .', ''), True, False)
+
                         p_non_blank[t][hyp_next] += (p_lm**alpha) * p_at_t[c] * (p_blank[t - 1][hyp] + p_non_blank[t - 1][hyp])
                     else:
                         p_non_blank[t][hyp_next] += p_at_t[c] * (p_blank[t - 1][hyp] + p_non_blank[t - 1][hyp])

--- a/audio8/test.py
+++ b/audio8/test.py
@@ -11,7 +11,7 @@ from torch.utils.data import DataLoader
 from eight_mile.utils import str2bool, Offsets, revlut
 from eight_mile.pytorch.layers import sequence_mask, find_latest_checkpoint
 from eight_mile.pytorch.optz import *
-from ctc import ctc_metrics, logits2text
+from ctc import ctc_metrics, logits2text, prefix_beam_search
 
 logger = logging.getLogger(__file__)
 
@@ -34,7 +34,7 @@ def run_step(index2vocab, model, batch, device, verbose=False):
         if verbose:
             logits = torch.argmax(logits[0], -1).tolist()
             input_lengths = input_lengths[0].item()
-            print(logits2text(logits[:input_lengths], index2vocab))
+            print(prefix_beam_search(logits[:input_lengths], index2vocab))
     return metrics
 
 

--- a/audio8/test.py
+++ b/audio8/test.py
@@ -36,7 +36,7 @@ def run_step(index2vocab, model, batch, device, verbose=False):
             for logits, input_lengths in zip(logits_batch, input_lengths_batch):
                 input_lengths = input_lengths.item()
                 probs = logits.exp().cpu().numpy()
-                transcription = prefix_beam_search(probs[:input_lengths, :], index2vocab, k=1)[0]
+                transcription = prefix_beam_search(probs[:input_lengths, :], index2vocab, beam=1)[0]
                 print(transcription)
 
     return metrics

--- a/audio8/train.py
+++ b/audio8/train.py
@@ -49,7 +49,7 @@ def run_step(index2vocab, model, batch, loss_function, device, verbose, training
             for logits, input_lengths in zip(logits_batch, input_lengths_batch):
                 input_lengths = input_lengths.item()
                 probs = logits.exp().cpu().numpy()
-                transcription = prefix_beam_search(probs[:input_lengths, :], index2vocab, k=1)[0]
+                transcription = prefix_beam_search(probs[:input_lengths, :], index2vocab, beam=1)[0]
                 print(transcription)
     return loss, metrics
 


### PR DESCRIPTION
This adds a prefix beam decoder, described in Hannun et al 2014 (https://arxiv.org/pdf/1408.2873.pdf) and based on
this article.

https://medium.com/corti-ai/ctc-networks-and-language-models-prefix-beam-search-explained-c11d1ee23306

The decoder defaults to the vocab names from wav2vec2 and converts internally.  The function works with or without
a language model -- if you want an LM you can download ARPA formatted ones or train your own with `kenlm`:

http://www.openslr.org/11

For decoding, we assume that the `kenlm` Python bindings are installed.  Install them with:

```
pip install https://github.com/kpu/kenlm/archive/master.zip
```
Once they are installed, you can load your LM (optionally) in your main program:

```python
from audio8.ctc import prefix_beam_search, kenlm_model
import kenlm
lm = kenlm.Model(args.lm)
logger.info("Found LM file, loading...")
```

And then call this code:

```python
logits_batch, pad_mask = ctc_model(x, x_mask)
input_lengths_batch = pad_mask.sum(-1)
for logits, input_lengths, text in zip(logits_batch, input_lengths_batch, batch['transcript']):
    input_lengths = input_lengths.item()
    probs = logits.exp().cpu().numpy()
    transcription = prefix_beam_search(probs[:input_lengths, :], index2vocab, language_model=kenlm_model(lm))
```
