### PR TITLE
adds option to resample audio on read

### DIFF
--- a/audio8/data.py
+++ b/audio8/data.py
@@ -20,13 +20,8 @@ logger = logging.getLogger(__file__)
 
 class SoundfileAudioReader:
 
-    def __init__(self, target_sample_rate=16_000):
-        self.target_sample_rate = target_sample_rate
-
     def read(self, file, max_length=-1):
-        wav, sr = sf.read(file)
-        if sr != self.target_sample_rate:
-            raise Exception(f"Expected {self.target_sample_rate} sampling rate")
+        wav, _ = sf.read(file)
         wav = wav.astype(np.float32)
 
         if max_length > 0:

--- a/audio8/data.py
+++ b/audio8/data.py
@@ -11,8 +11,50 @@ import soundfile as sf
 from torch.utils.data import DataLoader, IterableDataset
 from eight_mile.utils import Offsets
 from eight_mile.pytorch.optz import *
-
+try:
+    import torchaudio
+except:
+    pass
 logger = logging.getLogger(__file__)
+
+
+class SoundfileAudioReader:
+
+    def __init__(self, target_sample_rate=16_000):
+        self.target_sample_rate = target_sample_rate
+
+    def read(self, file, max_length=-1):
+        wav, sr = sf.read(file)
+        if sr != self.target_sample_rate:
+            raise Exception(f"Expected {self.target_sample_rate} sampling rate")
+        wav = wav.astype(np.float32)
+
+        if max_length > 0:
+            return wav[:max_length]
+
+        return wav
+
+
+class TorchAudioReader:
+
+    def transform(self, wav):
+        return wav
+
+    def read(self, file, max_length=-1):
+        wav, sr = torchaudio.load(file)
+        wav = self.transform(wav).view(-1)
+        if max_length > 0:
+            wav = wav[:max_length]
+
+        return wav.numpy()
+
+
+class AudioResampleReader(TorchAudioReader):
+    def __init__(self, input_sample_rate=8000, target_sample_rate=16_000):
+        self.resampler = torchaudio.transforms.Resample(orig_freq=input_sample_rate, new_freq=target_sample_rate)
+
+    def transform(self, wav):
+        return self.resampler(wav)
 
 
 def pad_init(shp, dtype=np.int32):
@@ -77,8 +119,10 @@ class AudioTextLetterDataset(IterableDataset):
     TGT_BPE = 'bpe'
     TGT_WRD = 'wrd'
 
-    def __init__(self, tsv_file, vec, target_tokens_per_batch, max_src_length, distribute=True, shuffle=True, max_dst_length=1200, tgt_type=TGT_LETTER):
+    def __init__(self, tsv_file, vec, target_tokens_per_batch, max_src_length, distribute=True, shuffle=True,
+                 max_dst_length=1200, tgt_type=TGT_LETTER, input_sample_rate=16_000, target_sample_rate=16_000):
         super().__init__()
+        self.reader = AudioResampleReader(input_sample_rate, target_sample_rate) if input_sample_rate != target_sample_rate else SoundfileAudioReader()
         self.min_src_length = 0  # TODO: remove?
         self.max_src_length = max_src_length
         self.max_dst_length = max_dst_length
@@ -200,15 +244,15 @@ class AudioTextLetterDataset(IterableDataset):
         :param file:
         :return:
         """
-        wav, _ = sf.read(file)
-        wav = wav.astype(np.float32)
-        return wav
+        return self.reader.read(file)
 
 
 class AudioFileDataset(IterableDataset):
 
-    def __init__(self, manifest, max_length, target_tokens_per_batch, distribute=True, shuffle=True,  min_length=0):
+    def __init__(self, manifest, max_length, target_tokens_per_batch, distribute=True,
+                 shuffle=True,  min_length=0, input_sample_rate=16_000, target_sample_rate=16_000):
         super().__init__()
+        self.reader = AudioResampleReader(input_sample_rate, target_sample_rate) if input_sample_rate != target_sample_rate else SoundfileAudioReader()
         self.max_length = max_length
         self.manifest = manifest
         self.rank = 0
@@ -285,14 +329,11 @@ class AudioFileDataset(IterableDataset):
         :param file:
         :return:
         """
-        wav, _ = sf.read(file)
-        wav = wav.astype(np.float32)
-        return wav[:len]
+        return self.reader.read(file, len)
 
     def __iter__(self):
 
         min_length = self.max_length
-
         num_tokens_predicted = 0
 
         samples = []

--- a/audio8/pretrain.py
+++ b/audio8/pretrain.py
@@ -32,7 +32,8 @@ def train():
                         help="dataset key for basedir")
     parser.add_argument("--num_vq_vars", type=int, default=320)
     parser.add_argument("--num_vq_groups", type=int, default=2)
-    parser.add_argument("--sr", type=int, choices=[8, 16], default=16)
+    parser.add_argument("--input_sample_rate", type=int, default=16_000)
+    parser.add_argument("--target_sample_rate", type=int, default=16_000)
     parser.add_argument("--d_model", type=int, default=768, help="Model dimension (and embedding dsz)")
     parser.add_argument("--d_ff", type=int, default=3072, help="FFN dimension")
     parser.add_argument("--num_heads", type=int, default=12, help="Number of heads")
@@ -100,8 +101,8 @@ def train():
     valid_loader = DataLoader(valid_set, batch_size=None)
     logger.info("Loaded datasets")
 
-    model = create_model(args.sr, args.num_vq_vars, args.num_vq_groups, args.d_model, args.num_heads, args.num_layers,
-                        args.dropout, args.d_ff).to(args.device)
+    model = create_model(args.target_sample_rate//1000, args.num_vq_vars, args.num_vq_groups, args.d_model, args.num_heads, args.num_layers,
+                         args.dropout, args.d_ff).to(args.device)
 
     loss_function = create_loss(args.num_vq_vars * args.num_vq_groups, 100).to(args.device)
     logger.info("Loaded model and loss")

--- a/audio8/pretrain_paired.py
+++ b/audio8/pretrain_paired.py
@@ -72,6 +72,8 @@ def train():
     parser.add_argument("--valid_dataset", type=str, help='Dataset (by name), e.g. dev-other')
     parser.add_argument("--subword_model_file", type=str, help="The BPE model file", required=True)
     parser.add_argument("--subword_vocab_file", type=str, help="The BPE subword vocab", required=True)
+    parser.add_argument("--input_sample_rate", type=int, default=16_000)
+    parser.add_argument("--target_sample_rate", type=int, default=16_000)
     parser.add_argument("--dataset_key", default="LibriSpeech",
                         help="dataset key for basedir")
     parser.add_argument("--grad_accum", type=int, default=1)
@@ -156,8 +158,12 @@ def train():
     train_dataset = os.path.join(args.root_dir, args.train_dataset)
     valid_dataset = os.path.join(args.root_dir, args.valid_dataset)
 
-    train_set = AudioTextLetterDataset(train_dataset, vec, args.target_tokens_per_batch, args.max_sample_len, shuffle=True, distribute=args.distributed, tgt_type=AudioTextLetterDataset.TGT_WRD)
-    valid_set = AudioTextLetterDataset(valid_dataset, vec, args.target_tokens_per_batch, args.max_sample_len, distribute=False, shuffle=False)
+    train_set = AudioTextLetterDataset(train_dataset, vec, args.target_tokens_per_batch, args.max_sample_len,
+                                       input_sample_rate=args.input_sample_rate, target_sample_rate=args.target_sample_rate,
+                                       shuffle=True, distribute=args.distributed, tgt_type=AudioTextLetterDataset.TGT_WRD)
+    valid_set = AudioTextLetterDataset(valid_dataset, vec, args.target_tokens_per_batch, args.max_sample_len,
+                                       input_sample_rate=args.input_sample_rate, target_sample_rate=args.target_sample_rate,
+                                       distribute=False, shuffle=False)
     train_loader = DataLoader(train_set, batch_size=None)  # , num_workers=args.num_train_workers)
     valid_loader = DataLoader(valid_set, batch_size=None)
 

--- a/audio8/test.py
+++ b/audio8/test.py
@@ -51,7 +51,8 @@ def evaluate():
     parser.add_argument("--dict_file", type=str, help="Dictionary file", default='dict.ltr.txt')
     parser.add_argument("--dataset_key", default="LibriSpeech",
                         help="dataset key for basedir")
-    parser.add_argument("--sr", type=int, choices=[8, 16], default=16)
+    parser.add_argument("--input_sample_rate", type=int, default=16_000)
+    parser.add_argument("--target_sample_rate", type=int, default=16_000)
     parser.add_argument("--d_model", type=int, default=768, help="Model dimension (and embedding dsz)")
     parser.add_argument("--d_ff", type=int, default=3072, help="FFN dimension")
     parser.add_argument("--d_k", type=int, default=None, help="Dimension per head.  Use if num_heads=1 to reduce dims")
@@ -81,12 +82,15 @@ def evaluate():
     index2vocab = revlut(vocab)
     valid_dataset = os.path.join(args.root_dir, args.valid_dataset)
 
-    valid_set = AudioTextLetterDataset(valid_dataset, vec, args.target_tokens_per_batch, args.max_sample_len, distribute=False, shuffle=False)
+    valid_set = AudioTextLetterDataset(valid_dataset, vec, args.target_tokens_per_batch, args.max_sample_len,
+                                       input_sample_rate=args.input_sample_rate,
+                                       target_sample_rate=args.target_sample_rate,
+                                       distribute=False, shuffle=False)
     valid_loader = DataLoader(valid_set, batch_size=None)
     logger.info("Loaded datasets")
 
     num_labels = len(vocab)
-    model = create_acoustic_model(num_labels, args.sr, args.d_model, args.num_heads, args.num_layers,
+    model = create_acoustic_model(num_labels, args.target_sample_rate//1000, args.d_model, args.num_heads, args.num_layers,
                                   0.0, args.d_ff).to(args.device)
 
     if not args.checkpoint:


### PR DESCRIPTION
if the sample rate of the input doesnt match
the target sample rate needed for the network,
we can resample it using torchaudio.transforms.

to support this, modify all the program usage to
include `input_sample_rate` and `target_sample_rate`
options and remove the `sr` option.  The new rate args
expect to be in frequency, so //1000 prior when passing
into the models to get the right conv filters