### PR TITLE
Remove torchaudio, use scipy for resampling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ COPY . /usr/audio8
 RUN apt-get update && apt-get install -y libasound2-dev libsndfile-dev
 RUN python3.6 -m pip install soundfile
 RUN python3.6 -m pip install regex
-
+RUN python3.6 -m pip install scipy


### PR DESCRIPTION
we were only using torchaudio for resampling, but
it was causing issues with the torch version installed
in a Docker container in multi-worker mode complaining that the
gfx driver isnt up-to-date, despite working fine when we dont pip
install torchaudio.  Its probably fixable but we werent
really using torchaudio for anything other than resampling.

In the future, we might want to just implement this functionality,
but in the interest of keeping it simple, `scipy.signal` offers both
polyphase convolution and FFT resampling and will definitely not
conflict with GPU driver.