### PR TITLE
Feature/pretok bpe

### DIFF
--- a/audio8/data.py
+++ b/audio8/data.py
@@ -160,7 +160,7 @@ class AudioTextLetterDataset(IterableDataset):
                         tokens = self.vec.run(text)
                     # If the data is already BPE, we dont want to re-tokenize it, we just have to convert it to ints
                     else:
-                        tokens = np.array([self.vec.vocab[t] for t in text], dtype=np.int)
+                        tokens = np.array([self.vec.vocab.get(t, Offsets.UNK) for t in text], dtype=np.int)
                     self.files.append(path)
                     self.sizes.append(x_length)
                     self.tokens.append(tokens)

--- a/audio8/data.py
+++ b/audio8/data.py
@@ -156,7 +156,11 @@ class AudioTextLetterDataset(IterableDataset):
                     if x_length < self.min_src_length or x_length > self.max_src_length:
                         continue
                     text = self._read_transcription(transcription)
-                    tokens = self.vec.run(text)
+                    if self.tgt_type != AudioTextLetterDataset.TGT_BPE:
+                        tokens = self.vec.run(text)
+                    # If the data is already BPE, we dont want to re-tokenize it, we just have to convert it to ints
+                    else:
+                        tokens = np.array([self.vec.vocab[t] for t in text], dtype=np.int)
                     self.files.append(path)
                     self.sizes.append(x_length)
                     self.tokens.append(tokens)

--- a/audio8/pretrain_paired.py
+++ b/audio8/pretrain_paired.py
@@ -130,6 +130,9 @@ def train():
     parser.add_argument("--vocab_file", help="Vocab for output decoding")
     parser.add_argument("--target_tokens_per_batch", type=int, default=700_000)
     parser.add_argument("--warmstart_text", help="Restore text encoder from an existing checkpoint")
+    parser.add_argument("--pretok", help="Is the text data already pre-tokenized into sub-words?",
+                        type=str2bool,
+                        default=False)
     parser.add_argument("--local_rank",
                         type=int,
                         default=-1,
@@ -158,12 +161,13 @@ def train():
     train_dataset = os.path.join(args.root_dir, args.train_dataset)
     valid_dataset = os.path.join(args.root_dir, args.valid_dataset)
 
+    tgt_type = AudioTextLetterDataset.TGT_BPE if args.pretok else AudioTextLetterDataset.TGT_WRD
     train_set = AudioTextLetterDataset(train_dataset, vec, args.target_tokens_per_batch, args.max_sample_len,
                                        input_sample_rate=args.input_sample_rate, target_sample_rate=args.target_sample_rate,
-                                       shuffle=True, distribute=args.distributed, tgt_type=AudioTextLetterDataset.TGT_WRD)
+                                       shuffle=True, distribute=args.distributed, tgt_type=tgt_type)
     valid_set = AudioTextLetterDataset(valid_dataset, vec, args.target_tokens_per_batch, args.max_sample_len,
                                        input_sample_rate=args.input_sample_rate, target_sample_rate=args.target_sample_rate,
-                                       distribute=False, shuffle=False, tgt_type=AudioTextLetterDataset.TGT_WRD)
+                                       distribute=False, shuffle=False, tgt_type=tgt_type)
     train_loader = DataLoader(train_set, batch_size=None)  # , num_workers=args.num_train_workers)
     valid_loader = DataLoader(valid_set, batch_size=None)
 


### PR DESCRIPTION
- Add option for pretokenized BPE transcriptions in the dual-encoder
- If the `tgt_type == TGT_BPE` just convert from string tokens to integer values
- The `mead-baseline` vectorizer has options to `emit_begin_tok` and `emit_end_tok`, assume that hasnt been done yet
  - Its a bit unclean how it reads these, it might be better in the future to have similar options on the a8 vectorizer and proxy if MBL is used