### PR TITLE
Feature/channel masking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ WORKDIR /usr/audio8
 COPY . /usr/audio8
 RUN apt-get update && apt-get install -y libasound2-dev libsndfile-dev
 RUN python3.6 -m pip install soundfile
-RUN python3.6 -m pip install regex
+RUN python3.6 -m pip install editdistance
 RUN python3.6 -m pip install scipy

--- a/audio8/pretrain.py
+++ b/audio8/pretrain.py
@@ -101,9 +101,7 @@ def train():
     valid_loader = DataLoader(valid_set, batch_size=None)
     logger.info("Loaded datasets")
 
-    model = create_model(args.target_sample_rate//1000, args.num_vq_vars, args.num_vq_groups, args.d_model, args.num_heads, args.num_layers,
-                         args.dropout, args.d_ff).to(args.device)
-
+    model = create_model(args.target_sample_rate//1000, **vars(args)).to(args.device)
     loss_function = create_loss(args.num_vq_vars * args.num_vq_groups, 100).to(args.device)
     logger.info("Loaded model and loss")
 

--- a/audio8/test.py
+++ b/audio8/test.py
@@ -90,8 +90,7 @@ def evaluate():
     logger.info("Loaded datasets")
 
     num_labels = len(vocab)
-    model = create_acoustic_model(num_labels, args.target_sample_rate//1000, args.d_model, args.num_heads, args.num_layers,
-                                  0.0, args.d_ff).to(args.device)
+    model = create_acoustic_model(num_labels, args.target_sample_rate//1000, **vars(args)).to(args.device)
 
     if not args.checkpoint:
         args.checkpoint = find_latest_checkpoint(args.basedir)

--- a/audio8/train.py
+++ b/audio8/train.py
@@ -145,8 +145,7 @@ def train():
     logger.info("Loaded datasets")
 
     num_labels = len(vocab)
-    model = create_acoustic_model(num_labels, args.target_sample_rate//1000, args.d_model, args.num_heads, args.num_layers,
-                                  args.dropout, args.d_ff).to(args.device)
+    model = create_acoustic_model(num_labels, args.target_sample_rate//1000, **vars(args)).to(args.device)
 
     loss_function = CTCLoss().to(args.device)
     logger.info("Loaded model and loss")

--- a/audio8/wav2vec2.py
+++ b/audio8/wav2vec2.py
@@ -224,15 +224,15 @@ def create_mask(
     return mask
 
 
-def create_model(sample_rate: int, num_vq_vars, num_vq_groups, d_model, num_heads, num_layers, dropout, d_ff):
+def create_model(sample_rate=16, num_vq_vars=320, num_vq_groups=2, d_model=768, num_heads=12, num_layers=12, dropout=0.1, d_ff=None, final_dim=256, dropout_input=0.1, dropout_features=0.1, timestep_masking=0.65, channel_masking=0.0, **kwargs):
     model = Wav2Vec2Model(CONV_FEATURES[sample_rate], num_vq_vars,
                           START_TEMP, END_TEMP, TEMP_DECAY_FACTOR, num_vq_groups, d_model,
                           num_heads, num_layers,
-                          dropout, d_ff)
+                          dropout, d_ff, final_dim, dropout_input, dropout_features, timestep_masking, channel_masking)
     return model
 
 
-def create_acoustic_model(num_labels, sample_rate, d_model, num_heads, num_layers, dropout, d_ff, dropout_input=0.0, timestep_masking=0.05, channel_masking=0.0016):
+def create_acoustic_model(num_labels, sample_rate=16, d_model=768, num_heads=12, num_layers=12, dropout=0.1, d_ff=None, dropout_input=0.0, timestep_masking=0.05, channel_masking=0.0016, **kwargs):
     model = Wav2Vec2AcousticModel(num_labels, CONV_FEATURES[sample_rate],
                                   d_model,
                                   num_heads, num_layers,
@@ -240,14 +240,16 @@ def create_acoustic_model(num_labels, sample_rate, d_model, num_heads, num_layer
     return model
 
 
-def create_paired_model(embeddings, target_sample_rate, audio_d_model=768, audio_num_heads=12, audio_num_layers=12, audio_dropout=0.1,
+def create_paired_model(embeddings, target_sample_rate=16, audio_d_model=768, audio_num_heads=12, audio_num_layers=12, audio_dropout=0.1,
                  audio_d_ff=3072, audio_reduction_type='max', audio_d_k=64,
+                 audio_dropout_input=0.0, audio_timestep_masking=0.05, audio_channel_masking=0.0016,
                  text_d_model=512, text_num_heads=8, text_num_layers=8, text_dropout=0.1, text_d_ff=2048, text_rpr_k=8,
                  text_reduction_type='max', text_d_k=64, stacking_layers=[],
                  output_dim=256, text_encoder_type='transformer', warmstart_text=None, **kwargs):
     audio_sr = target_sample_rate//1000
     audio_encoder = Wav2Vec2PooledEncoder(conv_features=CONV_FEATURES[audio_sr], d_model=audio_d_model, num_heads=audio_num_heads,
-                                          num_layers=audio_num_layers, dropout=audio_dropout, d_ff=audio_d_ff, reduction_type=audio_reduction_type, reduction_d_k=audio_d_k)
+                                          num_layers=audio_num_layers, dropout=audio_dropout, d_ff=audio_d_ff, reduction_type=audio_reduction_type, reduction_d_k=audio_d_k,
+                                          dropout_input=audio_dropout_input, timestep_masking=audio_timestep_masking, channel_masking=audio_channel_masking)
 
     if text_encoder_type == 'transformer':
 

--- a/audio8/wav2vec2.py
+++ b/audio8/wav2vec2.py
@@ -239,6 +239,7 @@ def create_acoustic_model(num_labels, sample_rate, d_model, num_heads, num_layer
                                   dropout, d_ff, dropout_input, 0.0, timestep_masking, channel_masking)
     return model
 
+
 def create_paired_model(embeddings, target_sample_rate, audio_d_model=768, audio_num_heads=12, audio_num_layers=12, audio_dropout=0.1,
                  audio_d_ff=3072, audio_reduction_type='max', audio_d_k=64,
                  text_d_model=512, text_num_heads=8, text_num_layers=8, text_dropout=0.1, text_d_ff=2048, text_rpr_k=8,
@@ -247,7 +248,6 @@ def create_paired_model(embeddings, target_sample_rate, audio_d_model=768, audio
     audio_sr = target_sample_rate//1000
     audio_encoder = Wav2Vec2PooledEncoder(conv_features=CONV_FEATURES[audio_sr], d_model=audio_d_model, num_heads=audio_num_heads,
                                           num_layers=audio_num_layers, dropout=audio_dropout, d_ff=audio_d_ff, reduction_type=audio_reduction_type, reduction_d_k=audio_d_k)
-
 
     if text_encoder_type == 'transformer':
 
@@ -262,6 +262,7 @@ def create_paired_model(embeddings, target_sample_rate, audio_d_model=768, audio
         text_encoder = TextBoWPooledEncoder(embeddings, reduction_type=text_reduction_type)
     de = BasicDualEncoderModel(audio_encoder, text_encoder, stacking_layers, output_dim)
     return de
+
 
 class Wav2Vec2Loss(nn.Module):
     def __init__(self, n_vars, n_negatives=100):
@@ -346,8 +347,7 @@ class ConvFeatureExtractionModel(nn.Module):
 
         for conv in self.conv_layers:
             x = conv(x)
-        # BxCxT -> BxTxC
-        #x = x.transpose(1, 2)
+
         return x
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ def fix_links(text):
     text = regex.sub(r"[\1]({}\2)".format(About.DOC_URL), text)
     return text
 
+
 def read_doc(f_name, new_name=None, fix_fn=fix_links):
     """
     Because our readme is outside of this dir we need to copy it in so
@@ -50,6 +51,7 @@ def read_doc(f_name, new_name=None, fix_fn=fix_links):
         shutil.copyfile(doc_loc, new_loc)
     descript = open(new_loc, 'r').read()
     return fix_fn(descript)
+
 
 def main():
     setup(
@@ -72,18 +74,11 @@ def main():
             'six',
             'soundfile',
             'editdistance',
-            'mead-layers',
+            'mead-baseline',
         ],
         extras_require={
-            'test': ['pytest', 'mock', 'contextdecorator', 'pytest-forked', 'onnxruntime'],
-            'report': ['visdom', 'tensorboard'],
-            'yaml': ['pyyaml'],
-            'bpe': ['fastBPE'],
-            'bpex': ['fastBPE', 'subword-nmt'],
-            'tf2': ['tensorflow_addons'],
-            'grpc': ['grpc'],
-            'onnx': ['onnxruntime'],
-            'tfrecord': ['tfrecord']
+            'test': ['pytest', 'mock', 'contextdecorator', 'pytest-forked'],
+            'scipy': ['scipy']
         },
         entry_points={
             'console_scripts': [
@@ -104,6 +99,7 @@ def main():
         },
         keywords=['deep-learning', 'audio', 'pytorch'],
     )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- Add channel masking
- Change booleans in downstream models to floats
- Drop inputs defaults to 0 for CTC
- Channel masking defaults to off in pretraining
- Channel masking and timestep masking default to on with defaults based on wav2vec2 paper
- Setup supports `scipy` optionally
- Dockerfile includes necessary deps