### PR TITLE
Fix/noreduce on accum

### DIFF
--- a/audio8/train.py
+++ b/audio8/train.py
@@ -5,6 +5,7 @@ import logging
 import time
 import torch
 import os
+import contextlib
 from argparse import ArgumentParser
 from audio8.data import AudioTextLetterDataset
 from audio8.text import TextVectorizer, read_vocab_file
@@ -272,7 +273,7 @@ def train():
     model.train()
     # All of our early stopping metrics currently need to be lower to be better, so set to high number initially
     best_metric = 1e8
-    eff_batch_size = 0
+    batch_size = 0
     num_tokens_this_batch = 0
     iters = 0
     last_validation_step = -1
@@ -293,30 +294,30 @@ def train():
             index2vocab, model, batch, loss_function, args.device, args.verbose, use_bpe=use_bpe
         )
         num_tokens_this_batch += step_metrics['num_tokens']
-        eff_batch_size += step_metrics['batch_size']
+        batch_size += step_metrics['batch_size']
         iters += 1
 
         try:
             avg_loss.update(loss.item())
-            loss.backward()
+
             if iters % args.grad_accum == 0:
-                # The effective batch size is iter_size * num_gpus * grad_accum
-                # When we DDP though, it does an average reduce, so we dont want any normalization
-                # going in, and because we only call step every grad_accum times our true average is
-                # scaled by grad_accum already.  If we scale up by the world_size then we get the unnormalized grads
-                # then we need to divide by the effective batch size
-                optimizer.scale_grads(num_gpus / eff_batch_size)
+                # This will allreduce the gradients which will be scaled by 1/num_gpus
+                loss.backward()
+                optimizer.scale_grads(num_gpus / batch_size)
                 torch.nn.utils.clip_grad_norm_(model.parameters(), args.clip)
                 # DDP does a mean reduction so scale by world size
                 optimizer.step()
                 optimizer.zero_grad()
-                batch_size_sent.update(eff_batch_size)
+                batch_size_sent.update(batch_size)
                 batch_size_toks.update(num_tokens_this_batch)
                 num_tokens_this_batch = 0
-                eff_batch_size = 0
+                batch_size = 0
                 elapsed = time.time() - start
                 step_time.update(elapsed)
                 start = time.time()
+            else:
+                with model.no_sync() if args.distributed else contextlib.ExitStack():
+                    loss.backward()
 
             if (optimizer.global_step + 1) % report_on == 0 and optimizer.global_step != last_report_step:
                 last_report_step = optimizer.global_step

--- a/audio8/train.py
+++ b/audio8/train.py
@@ -273,8 +273,9 @@ def train():
     model.train()
     # All of our early stopping metrics currently need to be lower to be better, so set to high number initially
     best_metric = 1e8
-    batch_size = 0
-    num_tokens_this_batch = 0
+    batch_size = torch.tensor(0)
+    num_tokens_this_batch = torch.tensor(0)
+
     iters = 0
     last_validation_step = -1
     last_report_step = -1
@@ -303,15 +304,18 @@ def train():
             if iters % args.grad_accum == 0:
                 # This will allreduce the gradients which will be scaled by 1/num_gpus
                 loss.backward()
+                if args.distributed:
+                    torch.distributed.all_reduce(batch_size)
+                    torch.distributed.all_reduce(num_tokens_this_batch)
                 optimizer.scale_grads(num_gpus / batch_size)
                 torch.nn.utils.clip_grad_norm_(model.parameters(), args.clip)
                 # DDP does a mean reduction so scale by world size
                 optimizer.step()
                 optimizer.zero_grad()
-                batch_size_sent.update(batch_size)
-                batch_size_toks.update(num_tokens_this_batch)
-                num_tokens_this_batch = 0
-                batch_size = 0
+                batch_size_sent.update(batch_size.item())
+                batch_size_toks.update(num_tokens_this_batch.item())
+                num_tokens_this_batch *= 0
+                batch_size *= 0
                 elapsed = time.time() - start
                 step_time.update(elapsed)
                 start = time.time()

--- a/audio8/train.py
+++ b/audio8/train.py
@@ -328,12 +328,13 @@ def train():
                 if step_time.avg != 0:
                     steps_per_sec = 1.0 / step_time.avg
                     logging.info(
-                        '%s, steps/min %f, LR %.6f, batch (sents %.2f, toks %.2f)',
+                        '%s, steps/min %f, LR %.6f, batch (samples %.2f, toks %.2f, toks/min %.2f)',
                         avg_loss,
                         steps_per_sec * 60,
                         optimizer.current_lr,
                         batch_size_sent.avg,
                         batch_size_toks.avg,
+                        batch_size_toks.avg * steps_per_sec * 60,
                     )
 
             if (

--- a/audio8/train.py
+++ b/audio8/train.py
@@ -273,8 +273,8 @@ def train():
     model.train()
     # All of our early stopping metrics currently need to be lower to be better, so set to high number initially
     best_metric = 1e8
-    batch_size = torch.tensor(0)
-    num_tokens_this_batch = torch.tensor(0)
+    batch_size = torch.tensor(0, device=args.device, dtype=int)
+    num_tokens_this_batch = torch.tensor(0, device=args.device, dtype=int)
 
     iters = 0
     last_validation_step = -1
@@ -312,8 +312,8 @@ def train():
                 # DDP does a mean reduction so scale by world size
                 optimizer.step()
                 optimizer.zero_grad()
-                batch_size_sent.update(batch_size.item())
-                batch_size_toks.update(num_tokens_this_batch.item())
+                batch_size_sent.update(batch_size.cpu().item())
+                batch_size_toks.update(num_tokens_this_batch.cpu().item())
                 num_tokens_this_batch *= 0
                 batch_size *= 0
                 elapsed = time.time() - start

--- a/audio8/train_seq2seq.py
+++ b/audio8/train_seq2seq.py
@@ -434,12 +434,13 @@ def train():
                 if step_time.avg != 0:
                     steps_per_sec = 1.0 / step_time.avg
                     logging.info(
-                        '%s, steps/min %f, LR %.6f, batch (sents %.2f, toks %.2f)',
+                        '%s, steps/min %f, LR %.6f, batch (samples %.2f, toks %.2f, toks/min %.2f)',
                         avg_loss,
                         steps_per_sec * 60,
                         optimizer.current_lr,
                         batch_size_sent.avg,
                         batch_size_toks.avg,
+                        batch_size_toks.avg * steps_per_sec * 60,
                     )
 
             if (

--- a/audio8/train_seq2seq.py
+++ b/audio8/train_seq2seq.py
@@ -381,8 +381,8 @@ def train():
     model.train()
     # All of our early stopping metrics currently need to be lower to be better, so set to high number initially
     best_metric = 1e8
-    batch_size = torch.tensor(0)
-    num_tokens_this_batch = torch.tensor(0)
+    batch_size = torch.tensor(0, device=args.device, dtype=int)
+    num_tokens_this_batch = torch.tensor(0, device=args.device, dtype=int)
     iters = 0
     last_validation_step = -1
     last_report_step = -1
@@ -411,6 +411,7 @@ def train():
                 # This will allreduce the gradients which will be scaled by 1/num_gpus
                 loss.backward()
                 if args.distributed:
+
                     torch.distributed.all_reduce(batch_size)
                     torch.distributed.all_reduce(num_tokens_this_batch)
                 optimizer.scale_grads(num_gpus / batch_size.item())
@@ -418,8 +419,8 @@ def train():
                 # DDP does a mean reduction so scale by world size
                 optimizer.step()
                 optimizer.zero_grad()
-                batch_size_sent.update(batch_size.item())
-                batch_size_toks.update(num_tokens_this_batch.item())
+                batch_size_sent.update(batch_size.cpu().item())
+                batch_size_toks.update(num_tokens_this_batch.cpu().item())
                 num_tokens_this_batch *= 0
                 batch_size *= 0
                 elapsed = time.time() - start


### PR DESCRIPTION
previously, we were doing syncing all backward calls, which caused the grad accum steps to also be allreduced, which doesnt make a lot of sense.  This is fixed by using `no_sync` from DDP on grad accum steps and doing NCCL allreduces on the no accum updates.  Also, the normalization should have been by effective batch size.  In the previous attempt these were being divided by local accumulated batch sizes which was a bug.  To get around this, do an allreduce on the batch and tokens metrics, which also makes for better reporting.